### PR TITLE
SDK version 1.5.1 Use only uuid for device id generation.

### DIFF
--- a/COMAPI/foundation/build.gradle
+++ b/COMAPI/foundation/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'com.comapi'
-    PUBLISH_VERSION = '1.5.0'
+    PUBLISH_VERSION = '1.5.1'
     PUBLISH_ARTIFACT_ID = 'foundation'
 }
 

--- a/COMAPI/foundation/src/main/java/com/comapi/BaseComapi.java
+++ b/COMAPI/foundation/src/main/java/com/comapi/BaseComapi.java
@@ -38,7 +38,7 @@ class BaseComapi {
     /**
      * Version of the ComapiImpl SDK MAJOR.MINOR.PATCH.BUILD
      */
-    private final static String SDK_VERSION = "1.5.0";
+    private final static String SDK_VERSION = "1.5.1";
 
     private static final Set<String> apiSpaces = Collections.synchronizedSet(new HashSet<String>());
 

--- a/COMAPI/foundation/src/main/java/com/comapi/internal/helpers/DeviceHelper.java
+++ b/COMAPI/foundation/src/main/java/com/comapi/internal/helpers/DeviceHelper.java
@@ -20,23 +20,14 @@
 
 package com.comapi.internal.helpers;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.net.wifi.WifiInfo;
-import android.net.wifi.WifiManager;
 import android.os.Build;
-import android.provider.Settings;
 import androidx.annotation.NonNull;
-import android.text.TextUtils;
-
-import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.installations.FirebaseInstallations;
 
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Helper to obtain basic device information.
@@ -72,60 +63,6 @@ public class DeviceHelper {
      */
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     public static String generateDeviceId(@NonNull Context context) {
-
-        String deviceId = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
-
-        if (TextUtils.isEmpty(deviceId)) {
-            deviceId = getMacAddress(context);
-        }
-
-        if (TextUtils.isEmpty(deviceId)) {
-            try {
-                deviceId = Tasks.await(FirebaseInstallations.getInstance().getId());
-            } catch (IllegalStateException e) {
-                //Continue.
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            } catch (ExecutionException e) {
-                e.printStackTrace();
-            }
-        }
-
-        if (TextUtils.isEmpty(deviceId)) {
-            deviceId = UUID.randomUUID().toString();
-        }
-
-        return deviceId;
-    }
-
-    /**
-     * Gets device mac address.
-     *
-     * @param context App context.
-     * @return Device mac address.
-     */
-    private static String getMacAddress(@NonNull Context context) {
-
-        if (isWifiStatePermissionGranted(context)) {
-            WifiManager wifiManager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-            if (wifiManager != null) {
-                WifiInfo wifiInfo = wifiManager.getConnectionInfo();
-                if (wifiInfo != null) {
-                    return wifiInfo.getMacAddress();
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Checks if the {@link Manifest.permission#ACCESS_WIFI_STATE} permission has been granted.
-     *
-     * @return True if wifi access permission has been granted.
-     */
-    private static boolean isWifiStatePermissionGranted(@NonNull Context context) {
-        int res = context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE);
-        return (res == PackageManager.PERMISSION_GRANTED);
+        return UUID.randomUUID().toString();
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Via Maven
 <dependency>
     <groupId>com.comapi</groupId>
     <artifactId>foundation</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 </dependency>
 ```
 
 or Gradle
 
 ```
-compile 'com.comapi:foundation:1.5.0'
+compile 'com.comapi:foundation:1.5.1'
 ```
 
 For more information about the integration please visit [the website](http://docs.cpaas.dotdigital.com/reference#one-sdk-android-overview).


### PR DESCRIPTION
Remove restricted Android IDs from generated device id.